### PR TITLE
Add combined test for decoding and encoding same message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "morse-codec"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "keyboard_query",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "morse-codec"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Barış Ürüm"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center" style="padding: 25px 0">
-  <img width="279" height="240" src="https://raw.githubusercontent.com/burumdev/morse-codec/refs/heads/master/morse-logo.png" alt="morse-codec logo" />
+  <img width="279" height="240" style="max-width: 279px" src="https://raw.githubusercontent.com/burumdev/morse-codec/refs/heads/master/morse-logo.png" alt="morse-codec logo" />
 </p>
 
 # morse-codec
@@ -27,8 +27,6 @@ prepared morse signals.
 
 Receives morse signals and decodes them character by character
 to create a byte array message with constant max length.
-Empty characters will be filled with the const FILLER_BYTE and
-decoding errors will be filled with DECODING_ERROR_BYTE.
 Trade-offs to support no_std include:
 * No vectors or any other type of dynamic heap memory used, all data is plain old stack arrays.
 * We decode the signals character by character instead of creating a large buffer for all
@@ -62,7 +60,7 @@ decoder.signal_event(412, false);
 
 Morse code encoder to turn text into morse code text or signals.
 
-The encoder takes **&str** literals or character bytes and
+Encoder takes **&str** literals or character bytes and
 turns them into a fixed length byte array. Then client code can encode these characters
 to morse code either one by one, from slices, or all in one go.
 

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -243,7 +243,8 @@ impl<const MSG_MAX: usize> MorseEncoder<MSG_MAX> {
             str_slice.chars()
                 .filter(|ch| ch.is_ascii())
                 .for_each(|ch| {
-                    self.encode_character(&(ch as u8)).unwrap();
+                    let byte = ch as u8;
+                    self.encode_character(&byte).unwrap();
                 });
 
             Ok(())

--- a/tests/test-decode-encode-combined.rs
+++ b/tests/test-decode-encode-combined.rs
@@ -1,0 +1,132 @@
+use morse_codec::{
+    decoder::Decoder,
+    encoder::{
+        Encoder,
+        MorseEncoder,
+        SDM,
+        MorseCharray,
+    }
+};
+
+use keyboard_query::{
+    DeviceQuery,
+    DeviceState,
+};
+
+use std::{
+    time::{ Instant, Duration },
+    thread::sleep,
+};
+
+const MSG_MAX: usize = 16;
+
+fn print_morse_charray(mchar: MorseCharray) {
+    for ch in mchar.iter().filter(|ch| ch.is_some()) {
+        print!("{}", ch.unwrap() as char);
+    }
+    print!(" ");
+}
+
+fn reencode_message(message: &str, morse_encoder: &mut MorseEncoder<MSG_MAX>) {
+    morse_encoder.message.set_message(message, false).unwrap();
+    morse_encoder.encode_message_all();
+    let encoded_charrays = morse_encoder.get_encoded_message_as_morse_charrays();
+
+    println!("Reencoded message as morse string: ");
+    encoded_charrays.for_each(|charray| print_morse_charray(charray.unwrap()));
+    println!();
+
+    println!("Now 'playing' reencoded message. You'll like it.");
+    let sdms = morse_encoder.get_encoded_message_as_sdm_arrays();
+
+    const SHORT_DURATION: u16 = 150;
+    sdms.enumerate().for_each(|(index, sdm_array)| {
+        println!("SDM array: {:?}", sdm_array);
+        println!("CHARACTER IS: {}", message.as_bytes()[index] as char);
+        sdm_array.unwrap().iter()
+            .filter(|&&sdm| sdm != SDM::Empty)
+            .for_each(|sdm| {
+                let duration = match sdm {
+                    SDM::High(mul) => {
+                        let d = *mul as u16 * SHORT_DURATION;
+                        println!("HIGH! ({}) ", d);
+
+                        d
+                    },
+                    SDM::Low(mul) => {
+                        let d = *mul as u16 * SHORT_DURATION;
+                        println!("LOW! ({}) ", d);
+
+                        d
+                    },
+                    _ => 0,
+                };
+
+                sleep(Duration::from_millis(duration as u64));
+            });
+    });
+}
+
+#[test]
+fn test_decode_encode_sdm() {
+    println!("TESTING DECODING AND THEN ENCODING DECODED MESSAGE");
+    println!("Message maximum length is: {}", MSG_MAX);
+
+    println!("\nPress 's' for a high signal, release 's' for a low signal, 'a' to end input and show the resulting message, 'q' to quit.");
+
+    let mut morse_decoder = Decoder::<MSG_MAX>::new()
+        .with_reference_short_ms(100)
+        .build();
+
+    let mut morse_encoder = Encoder::<MSG_MAX>::new().build();
+
+    let device_state = DeviceState::new();
+    let mut prev_keys = vec![];
+
+    let mut last_signal_time: Option<Instant> = None;
+    let mut last_space_time: Option<Instant> = None;
+
+    loop {
+        let keys = device_state.get_keys();
+        if keys != prev_keys {
+            if keys.len() == 1 {
+                if keys[0] == 31 { // Matching character 's' for signal
+                    if last_space_time.is_some() {
+                        let diff = last_space_time.unwrap().elapsed().as_millis();
+                        //println!("SPACE time diff = {} ms", diff);
+                        morse_decoder.signal_event(diff as u16, false);
+                    }
+
+                    last_signal_time = Some(Instant::now());
+                } else if keys[0] == 30 { // Matching character 'a' for all or end input
+                    morse_decoder.signal_event_end(false);
+
+                    let message = morse_decoder.message.as_str();
+
+                    println!();
+                    println!("Decoder message: {}", message);
+                    println!();
+
+                    println!("*****************************");
+                    println!("ENCODER REENCODES THE MESSAGE");
+                    println!("*****************************");
+
+                    reencode_message(message, &mut morse_encoder);
+                } else if keys[0] == 16 { // Character 'q' for quitting
+                    break;
+                }
+            } else if prev_keys.len() == 1 && prev_keys[0] == 31 && keys.is_empty() {
+                let diff = last_signal_time.unwrap().elapsed().as_millis();
+                //println!("SIGNAL time diff = {} ms", diff);
+                morse_decoder.signal_event(diff as u16, true);
+
+                last_space_time = Some(Instant::now());
+            }
+        }
+
+        prev_keys = keys;
+
+        // Sleep for 5 milliseconds (5000000 nanoseconds) to avoid clogging up resources
+        sleep(Duration::new(0, 5_000_000));
+    }
+}


### PR DESCRIPTION
In order to use the library as a communication tool between devices, we should be able to use both decoding and encoding functionality together.

This PR adds tests to to ensure decoding and encoding combined can work together to facilitate comms.