### PR TITLE
Add an optional clamping movement mode to message edit position

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "morse-codec"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "keyboard_query",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "morse-codec"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Barış Ürüm"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -117,9 +117,10 @@ new feature before incorporating it and reduces the back and forth dialogue requ
 All contributions will be licensed under the terms of MIT license shipped with this library.
 
 ## TODO
-* Make edit position cycling to the beginning optional. Currently edit position cycles to the beginning when overflows.
 * Support UTF-8 character set behind a feature flag that doesn't hurt embedded devices.
 * Support playing audio of encoded messages behind a feature flag.
+* Support [Farnsworth](https://www.arrl.org/files/file/Technology/x9004008.pdf) learning mode. Similar to lazy mode but more standardized.
+This only involves gaps between letters and words so it can be a third option between Lazy mode and Accurate.
 
 ## License
 This work is licensed under terms of MIT license as described here: https://opensource.org/license/mit

--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ Trade-offs to support no_std include:
   length to the decoder. A good intermediate value is 100 milliseconds.
 
 ```rust
-const MSG_MAX = 64;
-let decoder = morse_codec::Decoder::<MSG_MAX>::new()
+use morse_codec::decoder::Decoder;
+
+const MSG_MAX: usize = 64;
+let mut decoder = Decoder::<MSG_MAX>::new()
     .with_reference_short_ms(90)
     .build();
 
-// We receive a short high signal from button.
+// We receive high signal from button. 100 ms is a short dit signal.
 decoder.signal_event(100, true);
-// We receive a short low signal from the button.
+// We receive a low signal from the button. 80 ms low signal is a signal space dit.
 decoder.signal_event(80, false);
 // 328 ms high long signal is a dah.
 decoder.signal_event(328, true);
@@ -53,8 +55,10 @@ decoder.signal_event(412, false);
 // At this point the character will be decoded and added to the message.
 
 // Resulting character will be 'A' or '.-' in morse code.
-
+let message = decoder.message.as_str();
+assert_eq!(message, "A");
 ```
+
 
 * **Encoder**
 
@@ -68,13 +72,15 @@ Encoded morse code can be retrieved as morse character arrays ie. ['.','-','.'] 
 Duration Multipliers **SDMArray** to calculate individual signal durations by the client code.
 
 ```rust
-const MSG_MAX = 3;
-let encoder = morse_codec::Encoder::<MSG_MAX>::new()
-    // We have the message to encode ready and pass it to the builder.
-    // We pass true as second parameter to tell the encoder editing will
-    // continue from the end of this first string.
-    .with_message("SOS", true)
-    .build();
+use morse_codec::encoder::Encoder;
+
+const MSG_MAX: usize = 3;
+let mut encoder = Encoder::<MSG_MAX>::new()
+   // We have the message to encode ready and pass it to the builder.
+   // We pass true as second parameter to tell the encoder editing will
+   // continue from the end of this first string.
+   .with_message("SOS", true)
+   .build();
 
 // Encode the whole message
 encoder.encode_message_all();
@@ -82,14 +88,15 @@ encoder.encode_message_all();
 let encoded_charrays = encoder.get_encoded_message_as_morse_charrays();
 
 encoded_charrays.for_each(|charray| {
-    for ch in charray.unwrap().iter()
-        .filter(|ch| ch.is_some()) {
-            print!("{}", ch.unwrap() as char);
-        }
+   for ch in charray.unwrap().iter()
+       .filter(|ch| ch.is_some()) {
+           print!("{}", ch.unwrap() as char);
+       }
 
-    print!(" ");
+   print!(" ");
 });
 
+// This should print "... --- ..."
 ```
 
 ## Running Tests
@@ -117,6 +124,7 @@ new feature before incorporating it and reduces the back and forth dialogue requ
 All contributions will be licensed under the terms of MIT license shipped with this library.
 
 ## TODO
+* <strike>Make edit position cycling to the beginning optional. Currently edit position cycles to the beginning when overflows.</strike>
 * Support UTF-8 character set behind a feature flag that doesn't hurt embedded devices.
 * Support playing audio of encoded messages behind a feature flag.
 * Support [Farnsworth](https://www.arrl.org/files/file/Technology/x9004008.pdf) learning mode. Similar to lazy mode but more standardized.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ in practice.
 Use of `--nocapture` option with the test command is recommended. This will
 enable `println!()` outputs from the tests so that inputs and outputs can be observed.
 
+Running all tests at once is not recommended. Tests run asynchronously in Rust and this will
+result in intermingled `println!()` outputs. And I couldn't find a way to make `--test-threads 1`
+option to work reliably. Any ideas on that will be much appreciated.
+
+Let's get a list of available tests:
+```
+cargo test -- --list
+```
+And run tests with `--nocapture`
 ```
 cargo test decoding_live_lazy -- --nocapture
 ```

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -48,13 +48,14 @@ use core::ops::RangeInclusive;
 
 use crate::{
     message::Message,
-    CharacterSet, MorseCodeArray,
+    CharacterSet,
+    MorseCodeArray,
     MorseSignal::{self, Long as L, Short as S},
-    DECODING_ERROR_BYTE,
     MORSE_CODE_SET,
     DEFAULT_CHARACTER_SET,
     MORSE_ARRAY_LENGTH,
     MORSE_DEFAULT_CHAR,
+    DECODING_ERROR_BYTE,
     LONG_SIGNAL_MULTIPLIER,
     WORD_SPACE_MULTIPLIER,
 };
@@ -146,7 +147,7 @@ impl<const MSG_MAX: usize> Decoder<MSG_MAX> {
     /// edit_pos_end means we'll continue decoding from the end of this string.
     /// If you pass false to it, we'll start from the beginning.
     pub fn with_message(mut self, message_str: &str, edit_pos_end: bool) -> Self {
-        self.message = Message::new(message_str, edit_pos_end);
+        self.message = Message::new(message_str, edit_pos_end, self.message.is_edit_clamped());
 
         self
     }
@@ -208,6 +209,23 @@ impl<const MSG_MAX: usize> Decoder<MSG_MAX> {
         self
     }
 
+    /// Change the wrapping behaviour of message position to clamping.
+    ///
+    /// This will prevent the position cycling back to 0 when overflows or
+    /// jumping forward to max when falls below 0. Effectively limiting the position
+    /// to move within the message length from 0 to message length maximum without jumps.
+    ///
+    /// If at one point you want to change it back to wrapping:
+    ///
+    /// ```rust
+    /// decoder.message.set_edit_position_clamp(false);
+    /// ```
+    pub fn with_message_pos_clamping(mut self) -> Self {
+        self.message.set_edit_position_clamp(true);
+
+        self
+    }
+
     /// Build and get yourself a shiny new [MorseDecoder].
     ///
     /// The ring is yours now...
@@ -248,8 +266,8 @@ pub struct MorseDecoder<const MSG_MAX: usize> {
     character_set: CharacterSet,
     signal_tolerance: f32,
     reference_short_ms: MilliSeconds,
-    // Internal stuff
     pub message: Message<MSG_MAX>,
+    // Internal stuff
     current_character: MorseCodeArray,
     signal_pos: usize,
     signal_buffer: SignalBuffer,
@@ -401,15 +419,20 @@ impl<const MSG_MAX: usize> MorseDecoder<MSG_MAX> {
         if self.message.get_edit_pos() < MSG_MAX {
             let ch = self.get_char_from_morse_char(&self.current_character);
             self.message.add_char(ch);
-            self.message.shift_edit_right();
 
             self.reset_character();
         }
+
+        // If message position is clamping then this should not do anything.
+        // at the end of message position.
+        // If wrapping then it should reset the position to 0, so above condition
+        // should pass next time.
+        self.message.shift_edit_right();
     }
 
     /// Manually end a sequence of signals.
     ///
-    /// This decodes the current character and moves to the next one
+    /// This decodes the current character and moves to the next one.
     /// With end_word flag it will optionally add a space after it.
     /// Especially useful when client code can't determine if signal
     /// input by the operator ended, because no other high signal is

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -19,9 +19,11 @@
 //!   One way to fix the wrong decoding problems of 'T' character is to provide an initial reference short signal
 //!   length to the decoder. A good intermediate value is 100 milliseconds.
 //!
-//! ```
-//! const MSG_MAX = 64;
-//! let decoder = morse_codec::Decoder::<MSG_MAX>::new()
+//! ```rust
+//! use morse_codec::decoder::Decoder;
+//!
+//! const MSG_MAX: usize = 64;
+//! let mut decoder = Decoder::<MSG_MAX>::new()
 //!     .with_reference_short_ms(90)
 //!     .build();
 //!
@@ -40,7 +42,8 @@
 //! // At this point the character will be decoded and added to the message.
 //!
 //! // Resulting character will be 'A' or '.-' in morse code.
-//!
+//! let message = decoder.message.as_str();
+//! assert_eq!(message, "A");
 //! ```
 //!
 
@@ -217,6 +220,7 @@ impl<const MSG_MAX: usize> Decoder<MSG_MAX> {
     ///
     /// If at one point you want to change it back to wrapping:
     ///
+    /// ```ignore
     /// ```rust
     /// decoder.message.set_edit_position_clamp(false);
     /// ```
@@ -420,14 +424,14 @@ impl<const MSG_MAX: usize> MorseDecoder<MSG_MAX> {
             let ch = self.get_char_from_morse_char(&self.current_character);
             self.message.add_char(ch);
 
+            // If message position is clamping then this should not do anything.
+            // at the end of message position.
+            // If wrapping then it should reset the position to 0, so above condition
+            // should pass next time.
+            self.message.shift_edit_right();
+
             self.reset_character();
         }
-
-        // If message position is clamping then this should not do anything.
-        // at the end of message position.
-        // If wrapping then it should reset the position to 0, so above condition
-        // should pass next time.
-        self.message.shift_edit_right();
     }
 
     /// Manually end a sequence of signals.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,8 +136,8 @@ pub const MORSE_CODE_SET: [MorseCodeArray; CHARACTER_SET_LENGTH] = [
 /// It does not include special characters longer than 6 signals to keep arrays small. So no $ sign for ya.
 /// In order to change it and use a different mapping, client code can use [CharacterSet] type
 /// to construct an array of u8 with [CHARACTER_SET_LENGTH].
-///
-/// ```
+/// ```ignore
+/// ```rust
 /// let my_set: CharacterSet = [b' ', ...FILL IN THE CHARS...];
 /// let decoder = Decoder::<128>::new().with_character_set(my_set).build();
 /// ```

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,6 +3,7 @@
 //! Client code can use this to access and manipulate the
 //! internal message of [MorseDecoder] or [MorseEncoder]:
 //!
+//! ```ignore
 //! ```rust
 //! // Get a decoded message
 //! let decoded_message = decoder.message.as_str();

--- a/src/message.rs
+++ b/src/message.rs
@@ -30,6 +30,7 @@ use crate::{FILLER_BYTE, FILLER_CHAR};
 pub struct Message<const MSG_MAX: usize> {
     chars: [u8; MSG_MAX],
     edit_pos: usize,
+    clamp_edit_pos: bool,
 }
 
 impl<const MSG_MAX: usize> Default for Message<MSG_MAX> {
@@ -37,22 +38,24 @@ impl<const MSG_MAX: usize> Default for Message<MSG_MAX> {
         Self {
             chars: [FILLER_BYTE; MSG_MAX],
             edit_pos: 0,
+            clamp_edit_pos: false,
         }
     }
 }
 
 // Constructor with a starter string
 impl<const MSG_MAX: usize> Message<MSG_MAX> {
-    // Maximum index editing position can be at
-    const POS_MAX: usize = MSG_MAX - 1;
+    /// Maximum index editing position can be at
+    pub const POS_MAX: usize = MSG_MAX - 1;
 
     /// Get an instance of Message starting from an &str.
     ///
     /// edit_pos_end means client code wants to continue editing this
     /// text at the end.
-    pub fn new(message_str: &str, edit_pos_end: bool) -> Self {
+    pub fn new(message_str: &str, edit_pos_end: bool, clamp_edit_pos: bool) -> Self {
         let mut new_self = Self {
             chars: Self::str_to_bytes(message_str),
+            clamp_edit_pos,
             ..Self::default()
         };
 
@@ -112,6 +115,20 @@ impl<const MSG_MAX: usize> Message<MSG_MAX> {
         self.edit_pos = pos.clamp(0, Self::POS_MAX);
     }
 
+    /// Change the clamping behaviour of the edit position to
+    /// wrapping (default) or clamping.
+    ///
+    /// With clamping set, when edit position is shifted to left or right,
+    /// it won't cycle forward to maximum position or revert back to zero position,
+    /// effectively remaining within the limits of the message no matter current position is.
+    pub fn set_edit_position_clamp(&mut self, clamp: bool) {
+        self.clamp_edit_pos = clamp;
+    }
+
+    pub fn is_edit_clamped(&self) -> bool {
+        self.clamp_edit_pos
+    }
+
     /// Returns current editing position.
     pub fn get_edit_pos(&self) -> usize {
         self.edit_pos
@@ -121,7 +138,7 @@ impl<const MSG_MAX: usize> Message<MSG_MAX> {
     /// By default it will wrap to the end if position is 0
     pub fn shift_edit_left(&mut self) {
         self.edit_pos = match self.edit_pos {
-            0 => Self::POS_MAX,
+            0 => if self.clamp_edit_pos { 0 } else { Self::POS_MAX },
             p => p - 1,
         }
     }
@@ -130,7 +147,7 @@ impl<const MSG_MAX: usize> Message<MSG_MAX> {
     /// By default it will wrap to the beginning if position is POS_MAX
     pub fn shift_edit_right(&mut self) {
         self.edit_pos = match self.edit_pos {
-            p if p == Self::POS_MAX => 0,
+            p if p == Self::POS_MAX => if self.clamp_edit_pos { Self::POS_MAX } else { 0 },
             p => p + 1,
         }
     }

--- a/tests/test-decode-encode-combined.rs
+++ b/tests/test-decode-encode-combined.rs
@@ -28,6 +28,10 @@ fn print_morse_charray(mchar: MorseCharray) {
 }
 
 fn reencode_message(message: &str, morse_encoder: &mut MorseEncoder<MSG_MAX>) {
+    println!("*****************************");
+    println!("ENCODER REENCODES THE MESSAGE");
+    println!("*****************************");
+
     morse_encoder.message.set_message(message, false).unwrap();
     morse_encoder.encode_message_all();
     let encoded_charrays = morse_encoder.get_encoded_message_as_morse_charrays();
@@ -68,7 +72,7 @@ fn reencode_message(message: &str, morse_encoder: &mut MorseEncoder<MSG_MAX>) {
 }
 
 #[test]
-fn test_decode_encode_sdm() {
+fn decode_encode_sdm() {
     println!("TESTING DECODING AND THEN ENCODING DECODED MESSAGE");
     println!("Message maximum length is: {}", MSG_MAX);
 
@@ -106,10 +110,6 @@ fn test_decode_encode_sdm() {
                     println!();
                     println!("Decoder message: {}", message);
                     println!();
-
-                    println!("*****************************");
-                    println!("ENCODER REENCODES THE MESSAGE");
-                    println!("*****************************");
 
                     reencode_message(message, &mut morse_encoder);
                 } else if keys[0] == 16 { // Character 'q' for quitting

--- a/tests/test-decoding-programmatic.rs
+++ b/tests/test-decoding-programmatic.rs
@@ -489,3 +489,117 @@ fn set_get_message_str() {
     println!("Message length after rewrite: {}", decoder.message.len());
     println!("Edit position after rewrite is at: {}", decoder.message.get_edit_pos());
 }
+
+#[test]
+fn message_position_clamping() {
+    const MSG_MAX: usize = 7;
+
+    println!("TEST DECODING WITH MESSAGE POSITION CLAMPING BEHAVIOUR");
+
+    let mut decoder = Decoder::<MSG_MAX>::new().with_message_pos_clamping().build();
+
+    // Adding SOS to message till it overflows
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_current_char_to_message();
+
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_current_char_to_message();
+
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_current_char_to_message();
+
+    decoder.add_current_char_to_message();
+
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_current_char_to_message();
+
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_current_char_to_message();
+
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_current_char_to_message();
+
+    // This 'A' should be added to the end.
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_current_char_to_message();
+
+    // This 'B' should be added to the end.
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_current_char_to_message();
+
+    let message = decoder.message.as_str();
+
+    println!();
+    println!("Message after decoding 'SOS SOS' in {} length message", MSG_MAX);
+    println!("{}", message);
+    println!();
+
+    assert_eq!(message, "SOS SOB");
+
+    println!("Now let's restore wrapping behaviour and add some 'A's at the end");
+    decoder.message.set_edit_position_clamp(false);
+    decoder.message.clear();
+
+    // Adding SOS to message till it overflows
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_current_char_to_message();
+
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_current_char_to_message();
+
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_current_char_to_message();
+
+    decoder.add_current_char_to_message();
+
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_current_char_to_message();
+
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_current_char_to_message();
+
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_current_char_to_message();
+
+    // This 'A' should be decoded and added to the start of the message.
+    decoder.add_signal_to_character(Some(S));
+    decoder.add_signal_to_character(Some(L));
+    decoder.add_current_char_to_message();
+
+    let message = decoder.message.as_str();
+
+    println!();
+    println!("Message after decoding 'SOS SOS' in {} length message with wrapping behaviour and adding 'A' at the end:", MSG_MAX);
+    println!("{}", message);
+    println!();
+
+    assert_eq!(message, "AOS SOS");
+}

--- a/tests/test-encoding-programmatic.rs
+++ b/tests/test-encoding-programmatic.rs
@@ -230,3 +230,68 @@ fn encoding_fox_play_sdm() {
     });
 }
 
+#[test]
+fn message_position_clamping() {
+    const MSG_MAX: usize = 4;
+
+    println!("TESTING ENCODING WITH A CLAMPED EDIT POSITION");
+    println!("Message max length is {}", MSG_MAX);
+    println!();
+
+    let mut encoder = Encoder::<MSG_MAX>::new().with_message_pos_clamping().build();
+
+    encoder.encode_character(&b'R').unwrap();
+    encoder.encode_character(&b'U').unwrap();
+    encoder.encode_character(&b'S').unwrap();
+    encoder.encode_character(&b'T').unwrap();
+
+    let message = encoder.message.as_str();
+
+    println!("Message in the encoder: {}", message);
+
+    assert_eq!(message, "RUST");
+
+    let encoded_charrays = encoder.get_encoded_message_as_morse_charrays();
+    println!("Message as morse code:");
+    encoded_charrays.for_each(|charray| print_morse_charray(charray.unwrap()));
+
+    println!();
+
+    encoder.encode_character(&b'.').unwrap();
+    let message = encoder.message.as_str();
+    println!("Message in the encoder after adding a dot: {}", message);
+
+    assert_eq!(message, "RUS.");
+
+    println!();
+    println!("We clear the message and restart with a wrapping behaviour this time.");
+    encoder.message.clear();
+    encoder.message.set_edit_position_clamp(false);
+
+    encoder.encode_character(&b'R').unwrap();
+    encoder.encode_character(&b'U').unwrap();
+    encoder.encode_character(&b'S').unwrap();
+    encoder.encode_character(&b'T').unwrap();
+
+    let message = encoder.message.as_str();
+
+    println!("Message in the wrapping encoder: {}", message);
+
+    assert_eq!(message, "RUST");
+
+    let encoded_charrays = encoder.get_encoded_message_as_morse_charrays();
+    println!("Message in wrapping encoder as morse code:");
+    encoded_charrays.for_each(|charray| print_morse_charray(charray.unwrap()));
+
+    println!();
+
+    encoder.encode_character(&b'.').unwrap();
+    let message = encoder.message.as_str();
+    println!("Message in the wrapping encoder after adding a dot: {}", message);
+
+    assert_eq!(message, ".UST");
+
+    let encoded_charrays = encoder.get_encoded_message_as_morse_charrays();
+    println!("Message in wrapping encoder as morse code:");
+    encoded_charrays.for_each(|charray| print_morse_charray(charray.unwrap()));
+}


### PR DESCRIPTION
When shifting the edit position right or left and when it overflows from the beginning and the end of the message, default behavior is that it 'jumps' to the beginning or the end in wrapping fashion.

The goal of this PR is we add an option to the Decoder and Encoder builders that edit position will clamp to the beginning and the end of the message instead of wrapping around and jumping.