### PR TITLE
Add farnsworth precision support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "morse-codec"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 authors = ["Barış Ürüm"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@
 Rust library for live decoding and encoding of morse code messages. Supports multiple embedded devices and operating systems by being no_std.
 
 ## Summary
+
 You can create messages by sending individual high and low signals in milliseconds to decoder,
 from the keyboard, mouse clicks, or a button connected to some embedded device.
+Decoder supports three precision (difficulty) modes. Lazy (easiest), Accurate (Hardest) and
+[Farnsworth mode](https://www.arrl.org/files/file/Technology/x9004008.pdf) (somewhere inbetween).
 
 Use the encoder to turn your messages or characters into morse code strings or create a
 sequence of signals from the encoder to drive an external component such as an LED, step motor or speaker.

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ All contributions will be licensed under the terms of MIT license shipped with t
 * <strike>Make edit position cycling to the beginning optional. Currently edit position cycles to the beginning when overflows.</strike>
 * Support UTF-8 character set behind a feature flag that doesn't hurt embedded devices.
 * Support playing audio of encoded messages behind a feature flag.
-* Support [Farnsworth](https://www.arrl.org/files/file/Technology/x9004008.pdf) learning mode. Similar to lazy mode but more standardized.
-This only involves gaps between letters and words so it can be a third option between Lazy mode and Accurate.
+* <strike>Support [Farnsworth](https://www.arrl.org/files/file/Technology/x9004008.pdf) learning mode. Similar to lazy mode but more standardized.
+This only involves gaps between letters and words so it can be a third option between Lazy mode and Accurate.</strike>
 
 ## License
 This work is licensed under terms of MIT license as described here: https://opensource.org/license/mit

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -63,7 +63,7 @@ use crate::{
     WORD_SPACE_MULTIPLIER,
 };
 
-/// Decoding precision is either Lazy or Accurate.
+/// Decoding precision is either Lazy, Accurate or Farnsworth(speed_reduction_factor: f32).
 ///
 /// If Lazy is selected, short and long signals will be considered to saturate their
 /// fields on the extreme ends. For example a short signal can be 1 ms to short range end
@@ -72,13 +72,23 @@ use crate::{
 /// of lower tolerance value and higher tolerance value. Default value for tolerance factor is 0.5.
 /// So if a short signal is expected to be 100 ms, correct decoding signal can be anywhere between
 /// 50 ms to 150 ms, but not 10 ms.
+///
 /// Default precision is Lazy, as it's the most human friendly precision.
+///
+/// Farnsworth precision means extra delays will be added to spaces between characters and
+/// words but character decoding speed is not affected.
+/// Difference between current decoding speed and a reduced decoding speed will determine
+/// the length of the delays. The reduced decoding speed is determined by the factor value
+/// passed to the enum variant Farnsworth. This value will be multiplied by the current speed
+/// to find a reduction in overall speed. Factor value is clamped between 0.01 and 0.99.
 #[derive(Debug, PartialEq)]
 pub enum Precision {
     Lazy,
     Accurate,
+    Farnsworth(f32),
 }
-use Precision::{Accurate, Lazy};
+
+use Precision::{Lazy, Accurate, Farnsworth};
 
 type MilliSeconds = u16;
 
@@ -167,10 +177,30 @@ impl<const MSG_MAX: usize> Decoder<MSG_MAX> {
 
     /// Set decoder precision.
     ///
-    /// Precision::Lazy is more human friendly, Precision::Accurate is for learning
-    /// or a challenge contest.
+    /// * Precision::Lazy is more human friendly,
+    /// * Precision::Accurate is for learning or a challenge - contest.
+    /// * Precision::Farnsworth means extra delays will be added to spaces between characters and
+    ///     words but intracharacter speed is not affected.
+    ///     Difference between current decoding speed and a reduced decoding speed will determine
+    ///     the length of the delays. The reduced decoding speed is determined by the factor value
+    ///     passed to the enum variant Farnsworth. This value will be multiplied by the current speed
+    ///     to find a reduction in overall speed. Factor value will be clamped between 0.01 and 0.99.
+    ///
+    /// As an example for Farnsworth precision, let's say
+    /// client code wants a reduction to half the current speed:
+    /// ```ignore
+    /// let decoder = Decoder::new().with_precision(Precision::Farnsworth(0.5)).build();
+    /// // At this point if our words per minute speed is 20,
+    /// // overall transmission speed will be reduced to 10 WPM
+    /// // preserving the character speed at 20 WPM but distributing
+    /// // the difference in time among spaces between chars and words.
+    /// ```
     pub fn with_precision(mut self, precision: Precision) -> Self {
-        self.precision = precision;
+        if let Farnsworth(factor) = precision {
+            self.precision = Farnsworth(factor.clamp(0.01, 0.99));
+        } else {
+            self.precision = precision;
+        }
 
         self
     }
@@ -221,7 +251,6 @@ impl<const MSG_MAX: usize> Decoder<MSG_MAX> {
     /// If at one point you want to change it back to wrapping:
     ///
     /// ```ignore
-    /// ```rust
     /// decoder.message.set_edit_position_clamp(false);
     /// ```
     pub fn with_message_pos_clamping(mut self) -> Self {
@@ -336,8 +365,19 @@ impl<const MSG_MAX: usize> MorseDecoder<MSG_MAX> {
         &mut self,
         duration_ms: MilliSeconds,
         tolerance_range: &RangeInclusive<MilliSeconds>,
+        is_high: bool,
     ) -> SignalDuration {
         let short_tolerance_range = self.signal_tolerance_range(self.reference_short_ms);
+
+        let resolve_accurate = || -> SignalDuration {
+            if tolerance_range.contains(&self.reference_short_ms) {
+                SDShort(duration_ms)
+            } else if tolerance_range.contains(&self.long_signal_ms()) {
+                SDLong(duration_ms)
+            } else {
+                SDOther(duration_ms)
+            }
+        };
 
         match self.precision {
             Lazy => {
@@ -351,12 +391,21 @@ impl<const MSG_MAX: usize> MorseDecoder<MSG_MAX> {
                 }
             }
             Accurate => {
-                if tolerance_range.contains(&self.reference_short_ms) {
-                    SDShort(duration_ms)
-                } else if tolerance_range.contains(&self.long_signal_ms()) {
-                    SDLong(duration_ms)
+                resolve_accurate()
+            }
+            Farnsworth(factor) => {
+                if is_high {
+                    resolve_accurate()
                 } else {
-                    SDOther(duration_ms)
+                    let farnsworth_long = self.calculate_farnsworth_short(factor) * 3;
+
+                    if tolerance_range.contains(&self.reference_short_ms) {
+                        SDShort(duration_ms)
+                    } else if tolerance_range.contains(&farnsworth_long) {
+                        SDLong(duration_ms)
+                    } else {
+                        SDOther(duration_ms)
+                    }
                 }
             }
         }
@@ -383,13 +432,34 @@ impl<const MSG_MAX: usize> MorseDecoder<MSG_MAX> {
     }
 
     fn word_space_ms(&self) -> MilliSeconds {
-        let multiplier = if self.precision == Lazy {
-            9
-        } else {
-            WORD_SPACE_MULTIPLIER
+        let multiplier = match self.precision {
+            // Adding some padding to the end of word space to aid the lazy sleazy operator
+            Lazy => WORD_SPACE_MULTIPLIER + 1,
+            Accurate => WORD_SPACE_MULTIPLIER,
+            // Early return if we have a Farnsworth precision.
+            // We calculate the word space from a slower
+            // farnsworth short duration and return it.
+            Farnsworth(factor) => {
+                return self.calculate_farnsworth_short(factor) * WORD_SPACE_MULTIPLIER
+            }
         };
 
         self.reference_short_ms * multiplier
+    }
+
+    fn calculate_farnsworth_short(&self, speed_reduction_factor: f32) -> MilliSeconds {
+        // WPM stands for Words per Minute
+        let current_wpm = 1.2 / (self.reference_short_ms as f32 / 1000.0);
+        //println!("FARNSWORTH: current WPM: {}", current_wpm);
+
+        let reduced_wpm = current_wpm * speed_reduction_factor;
+        //println!("FARNSWORTH: reduced WPM: {}", reduced_wpm);
+
+        let delay_time_ms = (((60.0 * current_wpm) - (37.2 * reduced_wpm)) / (current_wpm * reduced_wpm)) * 1000.0;
+        //println!("FARNSWORTH: current reference short: {}", self.reference_short_ms);
+        //println!("FARNSWORTH: delay time total: {} and short: {}", delay_time_ms, (delay_time_ms / 19.0) as MilliSeconds);
+
+        (delay_time_ms / 19.0) as MilliSeconds
     }
 }
 
@@ -481,7 +551,7 @@ impl<const MSG_MAX: usize> MorseDecoder<MSG_MAX> {
                         //DBG
                         //println!("Initial ref short is set to {}", duration_ms);
                     } else {
-                        let resolved_duration = self.resolve_signal_duration(duration_ms, &tolerance_range);
+                        let resolved_duration = self.resolve_signal_duration(duration_ms, &tolerance_range, is_high);
 
                         //DBG
                         //println!("\tINTIAL HIGH: tolerance range: {:?}, position is: {}, resolved duration: {:?}, ref short is: {}", tolerance_range, pos, resolved_duration, self.reference_short_ms);
@@ -508,7 +578,7 @@ impl<const MSG_MAX: usize> MorseDecoder<MSG_MAX> {
                     self.update_reference_short_ms(duration_ms);
                 }
 
-                let resolved_duration = self.resolve_signal_duration(duration_ms, &tolerance_range);
+                let resolved_duration = self.resolve_signal_duration(duration_ms, &tolerance_range, is_high);
 
                 //DBG
                 //println!("LOW SIGNAL: tolerance range: {:?}, position is: {}, resolved duration: {:?}, ref short is: {}", tolerance_range, _pos, resolved_duration, self.reference_short_ms);
@@ -544,7 +614,7 @@ impl<const MSG_MAX: usize> MorseDecoder<MSG_MAX> {
             // The reason why we check at this position starting from index 2+ is that
             // we get a better calibrated short signal from the low signal before it (index 1)
             pos if pos < SIGNAL_BUFFER_LENGTH && is_high => {
-                let resolved_duration = self.resolve_signal_duration(duration_ms, &tolerance_range);
+                let resolved_duration = self.resolve_signal_duration(duration_ms, &tolerance_range, is_high);
 
                 //DBG
                 //println!("\tHIGH SIGNAL: tolerance range: {:?}, position is: {}, resolved duration: {:?}, ref short is: {}", tolerance_range, pos, resolved_duration, self.reference_short_ms);

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -140,7 +140,6 @@ impl<const MSG_MAX: usize> Encoder<MSG_MAX> {
     /// If at one point you want to change it back to wrapping again:
     ///
     /// ```ignore
-    /// ```rust
     /// encoder.message.set_edit_position_clamp(false);
     /// ```
     pub fn with_message_pos_clamping(mut self) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,11 @@
 //!
 //! You can create messages by sending individual high and low signals in milliseconds to decoder,
 //! from the keyboard, mouse clicks, or a button connected to some embedded device.
+//! Decoder supports three precision (difficulty) modes. Lazy (easiest), Accurate(Hardest) and
+//! Farnsworth mode (somewhere inbetween)
 //!
 //! Use the encoder to turn your messages or characters into morse code strings or create a
-//! sequence of signals from the encoder to drive an external component such as an LED, step motor or speaker.
+//! sequence of signals to drive an external component such as an LED, step motor or speaker.
 //!
 //! # Features
 //! * Decoder

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,6 @@ pub const MORSE_CODE_SET: [MorseCodeArray; CHARACTER_SET_LENGTH] = [
 /// In order to change it and use a different mapping, client code can use [CharacterSet] type
 /// to construct an array of u8 with [CHARACTER_SET_LENGTH].
 /// ```ignore
-/// ```rust
 /// let my_set: CharacterSet = [b' ', ...FILL IN THE CHARS...];
 /// let decoder = Decoder::<128>::new().with_character_set(my_set).build();
 /// ```

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,10 +1,9 @@
 //! Message struct to hold decoded message or message to be encoded.
 //!
 //! Client code can use this to access and manipulate the
-//! internal message of [MorseDecoder] or [MorseEncoder]:
+//! internal message of MorseDecoder or MorseEncoder:
 //!
 //! ```ignore
-//! ```rust
 //! // Get a decoded message
 //! let decoded_message = decoder.message.as_str();
 //! let decoded_message_bytes = decoder.message.as_bytes();
@@ -15,7 +14,7 @@
 //!
 //! // Set message to something different
 //! // and continue decoding from the end
-//! decoder.set_message("SOME INITIAL MESSAGE", true);
+//! decoder.message.set_message("SOME INITIAL MESSAGE", true);
 //!
 //! // We continue sending signals
 //! decoder.signal_event(125, true);

--- a/tests/test-decoding-live.rs
+++ b/tests/test-decoding-live.rs
@@ -97,3 +97,13 @@ fn decoding_live_lazy() {
 fn decoding_live_100_ms() {
     decoding_live(Precision::Lazy, 100);
 }
+
+#[test]
+fn decoding_live_farnsworth_half() {
+    decoding_live(Precision::Farnsworth(0.5), 100);
+}
+
+#[test]
+fn decoding_live_farnsworth_quarter() {
+    decoding_live(Precision::Farnsworth(0.25), 100);
+}


### PR DESCRIPTION
Based on the info about Farnsworth delay calculations on this [whitepaper](https://www.arrl.org/files/file/Technology/x9004008.pdf), we add support for Farnsworth learning mode.