### PR TITLE
Option to get current signal speed in words per minute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "morse-codec"
-version = "0.2.2"
+version = "0.3.1"
 dependencies = [
  "keyboard_query",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "morse-codec"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Barış Ürüm"]
 license = "MIT"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -444,7 +444,7 @@ impl<const MSG_MAX: usize> MorseDecoder<MSG_MAX> {
 
     fn calculate_farnsworth_short(&self, speed_reduction_factor: f32) -> MilliSeconds {
         // WPM stands for Words per Minute
-        let current_wpm = 1.2 / (self.reference_short_ms as f32 / 1000.0);
+        let current_wpm = self.get_wpm() as f32;
         //println!("FARNSWORTH: current WPM: {}", current_wpm);
 
         let reduced_wpm = current_wpm * speed_reduction_factor;
@@ -467,6 +467,12 @@ impl<const MSG_MAX: usize> MorseDecoder<MSG_MAX> {
     /// it might be useful for the client code.
     pub fn get_reference_short(&self) -> MilliSeconds {
         self.reference_short_ms
+    }
+
+    /// Returns the current signal entry speed in
+    /// Words Per Minute format.
+    pub fn get_wpm(&self) -> u16 {
+        (1.2 / (self.reference_short_ms as f32 / 1000.0)) as u16
     }
 
     /// Directly add a prepared signal to the character.

--- a/tests/test-decoding-live.rs
+++ b/tests/test-decoding-live.rs
@@ -63,6 +63,7 @@ fn decoding_live(precision: Precision, initial_short: u16) {
                             print!("{}", message[i] as char);
                         }
                         println!();
+                        println!("Current speed in Words Per Minute is {}", decoder.get_wpm());
                     }
                 } else if keys[0] == 16 { // Character 'q' for quitting
                     break;


### PR DESCRIPTION
As a continuation of the previous PR that enabled Farnsworth mode, we can now return the decoding speed in Words Per Minute.