### PR TITLE
Refactor last edited index to correctly return last operation result

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "morse-codec"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "keyboard_query",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "morse-codec"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Barış Ürüm"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ assert_eq!(message, "A");
 
 Morse code encoder to turn text into morse code text or signals.
 
-Encoder takes **&str** literals or character bytes and
+Encoder takes **&str** literals or characters and
 turns them into a fixed length array. Then client code can encode these characters
 to morse code either one by one, from slices, or all in one go.
 
@@ -84,7 +84,7 @@ Duration Multipliers **SDMArray** to calculate individual signal durations by th
 ```rust
 use morse_codec::encoder::Encoder;
 
-const MSG_MAX: usize = 3;
+const MSG_MAX: usize = 16;
 let mut encoder = Encoder::<MSG_MAX>::new()
    // We have the message to encode ready and pass it to the builder.
    // We pass true as second parameter to tell the encoder editing will

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -468,6 +468,11 @@ impl<const MSG_MAX: usize> MorseDecoder<MSG_MAX> {
         (1.2 / (self.reference_short_ms as f32 / 1000.0)) as u16
     }
 
+    /// Returns last decoded character for easy access.
+    pub fn get_last_decoded_char(&self) -> Character {
+        self.message.get_last_changed_char()
+    }
+
     /// Directly add a prepared signal to the character.
     ///
     /// Signal duration resolving is done by the client code, or you're using a prepared signal.

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,6 +1,6 @@
 //! Morse code encoder to turn text into morse code text or signals.
 //!
-//! The encoder takes [&str] literals or character bytes and
+//! The encoder takes [&str] literals or characters and
 //! turns them into a fixed length char array. Then client code can encode these characters
 //! to morse code either character by character, from slices, or all in one go.  
 //! Encoded morse code can be retrieved as morse character arrays ie. ['.','-','.'] or Signal
@@ -11,7 +11,7 @@
 //! ```rust
 //! use morse_codec::encoder::Encoder;
 //!
-//! const MSG_MAX: usize = 3;
+//! const MSG_MAX: usize = 16;
 //! let mut encoder = Encoder::<MSG_MAX>::new()
 //!    // We have the message to encode ready and pass it to the builder.
 //!    // We pass true as second parameter to tell the encoder editing will
@@ -375,14 +375,14 @@ impl<const MSG_MAX: usize> MorseEncoder<MSG_MAX> {
     }
 
     // OUTPUTS
-    /// Get last encoded message character as `Option<u8>` byte arrays of morse code.
+    /// Get last encoded message character as `Option<Character>` arrays of morse code.
     ///
     /// Arrays will have a fixed length of `MORSE_ARRAY_LENGTH` and if there's no
     /// signal the option will be None.
     pub fn get_last_char_as_morse_charray(&self) -> Option<MorseCharray> {
-        let pos = self.message.get_edit_pos();
+        let pos = self.message.get_last_changed_index();
         if pos > 0 {
-            self.get_encoded_char_as_morse_charray(pos - 1)
+            self.get_encoded_char_as_morse_charray(pos)
         } else {
             None
         }
@@ -394,15 +394,15 @@ impl<const MSG_MAX: usize> MorseEncoder<MSG_MAX> {
     /// signals to play or animate the morse code.
     /// It'll be great to filter-out `Empty` values of SDM arrays.
     pub fn get_last_char_as_sdm(&self) -> Option<SDMArray> {
-        let pos = self.message.get_edit_pos();
+        let pos = self.message.get_last_changed_index();
         if pos > 0 {
-            self.get_encoded_char_as_sdm(pos - 1)
+            self.get_encoded_char_as_sdm(pos)
         } else {
             None
         }
     }
 
-    /// Get an iterator to encoded message as `Option<u8>` byte arrays of morse code.
+    /// Get an iterator to encoded message as `Option<Character>` arrays of morse code.
     /// Arrays will have a fixed length of `MORSE_ARRAY_LENGTH` and if there's no
     /// signal the option will be `None`. So it will be good to filter them out.
     pub fn get_encoded_message_as_morse_charrays(&self) -> impl Iterator<Item = Option<MorseCharray>> + '_ {

--- a/tests/test-decoding-programmatic.rs
+++ b/tests/test-decoding-programmatic.rs
@@ -618,3 +618,80 @@ fn message_position_clamping() {
 
     assert_eq!(message, "AOS SOS");
 }
+
+#[test]
+fn decode_random_positions() {
+    const MSG_MAX: usize = 16;
+
+    println!("TEST DECODING AT RANDOM POSITIONS");
+
+    let mut decoder = Decoder::<MSG_MAX>::new()
+        .with_edit_position(8)
+        .with_message_pos_clamping()
+        .build();
+
+    println!();
+
+    print!("DECODED CHARS: ");
+    decoder.signal_event(100, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(100, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(100, true);
+    decoder.signal_event(300, false);
+
+    print!("{}", decoder.get_last_decoded_char());
+
+    decoder.signal_event(300, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(300, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(300, true);
+    decoder.signal_event(300, false);
+
+    print!("{}", decoder.get_last_decoded_char());
+
+    decoder.signal_event(100, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(100, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(100, true);
+    decoder.signal_event(300, false);
+
+    print!("{}", decoder.get_last_decoded_char());
+
+    decoder.message.set_edit_pos(3);
+
+    decoder.signal_event(300, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(300, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(300, true);
+    decoder.signal_event(300, false);
+
+    print!("{}", decoder.get_last_decoded_char());
+
+    decoder.signal_event(100, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(100, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(100, true);
+    decoder.signal_event(300, false);
+
+    print!("{}", decoder.get_last_decoded_char());
+
+    decoder.signal_event(300, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(300, true);
+    decoder.signal_event(100, false);
+    decoder.signal_event(300, true);
+    decoder.signal_event(300, false);
+
+    print!("{}", decoder.get_last_decoded_char());
+
+    println!();
+
+    println!("Resulting message at random inputs: '{}'", decoder.message.as_str());
+
+    println!();
+}


### PR DESCRIPTION
`get_last_char....` like functions used to rely on editing position, but this might result in wrong results. We keep a buffer of last operation character index to accurately return last edited character.